### PR TITLE
add video description and shorten long descriptions using util function

### DIFF
--- a/src/components/youtube/Media.tsx
+++ b/src/components/youtube/Media.tsx
@@ -20,6 +20,7 @@ import { useEffect, useState } from "react";
 import youtube from "../apis/youtube";
 import { formatCount } from "../../utils/kFormatter";
 import { ageCalculator } from "../../utils/ageCalculator";
+import { showNchars } from "../../utils/showNchars";
 
 interface Props {
   video: object;
@@ -36,6 +37,7 @@ interface VideoInfo {
   snippet?: {
     title: string;
     channelTitle: string;
+    description: string;
     publishedAt: Date;
     tags: string[];
   };
@@ -60,6 +62,7 @@ const Media: React.FC<Props> = ({ video }) => {
         },
       });
       setSingleVideo(response.data.items[0]);
+      console.log(singleVideo);
     };
     fetchVideoDetails();
   }, [video]);
@@ -83,6 +86,20 @@ const Media: React.FC<Props> = ({ video }) => {
         </Link>
         <Text>
           Published on {snippet?.publishedAt.toString().substring(0, 10)}
+        </Text>
+      </Box>
+
+      {/* Description */}
+      <Box m={5}>
+        <Heading size="sm">Description:</Heading>
+        <Text>
+          {showNchars(snippet?.description)}
+          <Link
+            href={`https://www.youtube.com/watch?v=${id?.videoId}`}
+            isExternal
+          >
+            ...
+          </Link>
         </Text>
       </Box>
 

--- a/src/utils/showNchars.ts
+++ b/src/utils/showNchars.ts
@@ -1,0 +1,26 @@
+export const showNchars = (str: string | undefined) => {
+  if (!str) return;
+  let shortenedStr = str.substring(0, 100);
+  /*
+  "merc v" -> "merc"
+  "merc vapo" -> "merc"
+  "merc " -> "merc "
+
+  if the last char of the str is NOT empty string
+    start iterating from the last char until we hit empty char (left-to-right iteration)
+    when we hit the empty char, use the index of the empty char to return a shortened string using substring method
+
+  */
+
+  const len = shortenedStr.length;
+
+  if (shortenedStr[len - 1] === " ") {
+    return shortenedStr;
+  } else {
+    for (let i = len - 1; i >= 0; i--) {
+      if (shortenedStr[i] === " ") {
+        return shortenedStr.substring(0, i + 1);
+      }
+    }
+  }
+};


### PR DESCRIPTION
Fetching video description was easy; however, some videos contain unusually long descriptions that can lead to unpleasant UI experience if rendered. Therefore, an util function that limits the description 100 characters,  handles spaces properly, and shows three dots at the end that users can click to travel to the actual video page.

solves #12 